### PR TITLE
text-link() mixin improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Your underlines can be initialised where necessary using the `text-link()` mixin
     }
 ```
 
-This mixin is intended to be used with inline links, and may behave unpredictably with `inline-block` elements. To rectify, you can choose to adjust the `link-offset` or override the `background-position` value.
+This mixin is intended to be used with inline links, but will also work with `inline-block` *if* top and bottom padding is equal. Otherwise, you can manually adjust the `link-offset` value to correct for uneven padding.
 
 Alternatively, you can remove fancy underlines by including the `reset-link()` mixin on the element.
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,32 @@ $debug-allow: true;
 
 **Note:** Background gradients are used for some debugging elements. As background gradients suffer from pixel rounding issues, they may get out of sync on some configurations with extreme dimensions (on lengthy typeset pages, for example). This is an unfortunate, but expected behaviour.
 
+### Fancy underlines
+MegaType also includes a mixin to make your link underlines look great. The global variables in `_config.scss` control their default settings:
+
+```scss
+// Link offset from baseline. Can be a positive or negative value
+$link-offset: 2px !default;
+
+// Opacity of the underline.
+$link-underline-opacity: 0.6 !default;
+
+// Opacity of the underline when hovered.
+$link-underline-hover-opacity: 0.8 !default;
+```
+
+Your underlines can be initialised where necessary using the `text-link()` mixin. By default, it will use the variables above - however, you can override them in-context if necessary.
+
+```scss
+    a {
+        @include text-link($color: palette(blue), $hover: $color, $offset: $link-offset, $opacity: $link-underline-opacity, $hover-opacity: $link-underline-hover-opacity);
+    }
+```
+
+This mixin is intended to be used with inline links, and may behave unpredictably with `inline-block` elements. To rectify, you can choose to adjust the `link-offset` or override the `background-position` value.
+
+Alternatively, you can remove fancy underlines by including the `reset-link()` mixin on the element.
+
 ###Why did we make this?
 Web typography, as we see it, is broken. For a full explanation on why MegaType exists, [read our blog post!](http://www.studiothick.com/essays/web-typography-is-broken)
 

--- a/megatype/_config.scss
+++ b/megatype/_config.scss
@@ -99,10 +99,16 @@ $min-font-size: false !default;
 // typographic measure for paragraphs, lists, and headings
 $type-measure: 40rem !default;
 
+
 // link offset from baseline
 $link-offset: 2px !default;
-$link-opacity: 0.6 !default;
-$link-hover-opacity: 0.8 !default;
+
+// link underline opacity
+$link-underline-opacity: 0.6 !default;
+
+// link underline hover opacity
+$link-underline-hover-opacity: 0.8 !default;
+
 
 // breakpoint count
 $breakpoint-count: length(map-keys($breakpoint-map)) !default;

--- a/megatype/_config.scss
+++ b/megatype/_config.scss
@@ -97,10 +97,12 @@ $breakpoint-map: (
 $min-font-size: false !default;
 
 // typographic measure for paragraphs, lists, and headings
-$type-measure: 40rem;
+$type-measure: 40rem !default;
 
 // link offset from baseline
-$link-offset: 2px;
+$link-offset: 2px !default;
+$link-opacity: 0.6 !default;
+$link-hover-opacity: 0.8 !default;
 
 // breakpoint count
 $breakpoint-count: length(map-keys($breakpoint-map)) !default;

--- a/megatype/_text-link.scss
+++ b/megatype/_text-link.scss
@@ -7,31 +7,25 @@
 
 
 // better text decoration
-@mixin text-link($color: palette(blue), $hover: $color, $hover-opacity: 0.6) {
-    $transparency: 0.6;
-
-    @if ($color == white or $color == #fff or $color == #ffffff) {
-        $transparency: 0.25;
-    }
+@mixin text-link($color: palette(blue), $hover: $color, $offset: $link-offset, $opacity: $link-opacity, $hover-opacity: $link-hover-opacity) {
 
     color: $color;
-    background-image: linear-gradient(to bottom,rgba(0, 0, 0, 0) 50%,transparentize($color, $transparency) 50%);
+    text-decoration: none;
+    background-image: linear-gradient(to bottom,rgba(0, 0, 0, 0) 50%, rgba($color, $opacity) 50%);
     background-repeat: repeat-x;
     background-size: 2px 2px;
-    // background-position: inherit;
+    background-position: 0 1.05em;
+    background-position: 0 calc(43% + 0.44em + #{$offset});
     cursor: pointer;
 
-    @if $color == $hover and $hover-opacity == 0.6 {
-        $hover-opacity: 0.3;
-    }
 
     @if $hover != false {
         &:hover {
             @if $hover == $color and $hover != #fff and $hover != white {
-                background-image: linear-gradient(to bottom,rgba(0, 0, 0, 0) 50%,transparentize(darken($hover, 20%), $hover-opacity) 50%);
+                background-image: linear-gradient(to bottom,rgba(0, 0, 0, 0) 50%, rgba(darken($hover, 20%), $hover-opacity) 50%);
                 color: darken($hover, 20%);
             } @else {
-                background-image: linear-gradient(to bottom,rgba(0, 0, 0, 0) 50%,transparentize($hover, $hover-opacity) 50%);
+                background-image: linear-gradient(to bottom,rgba(0, 0, 0, 0) 50%, rgba($hover, $hover-opacity) 50%);
                 color: $hover;
             }
         }

--- a/megatype/_text-link.scss
+++ b/megatype/_text-link.scss
@@ -7,7 +7,7 @@
 
 
 // better text decoration
-@mixin text-link($color: palette(blue), $hover: $color, $offset: $link-offset, $opacity: $link-opacity, $hover-opacity: $link-hover-opacity) {
+@mixin text-link($color: palette(blue), $hover: $color, $offset: $link-offset, $opacity: $link-underline-opacity, $hover-opacity: $link-underline-hover-opacity) {
 
     color: $color;
     text-decoration: none;

--- a/megatype/_typography.scss
+++ b/megatype/_typography.scss
@@ -305,16 +305,6 @@
     }
 
 
-    // Now let's set a few handy helpers for nested links
-    // set background position for link underlines
-    &, a {
-        background-position: 0 round($fontsize + $type-space + $link-offset);
-        background-position: 0 calc(50% + #{$fontsize + $type-space + $link-offset});
-    }
-
-    a {
-        @extend %typeset-child;
-    }
 
     // apply debugging
     @if $debug-hover == true {


### PR DESCRIPTION
Fix for #14 
- Modified `text-link()` mixin with improved order of variables
- Replaced per-element background-position with a universal value intended for `display: inline` elements
- Exposed offset and underline opacity settings in mixin
- Added new global variables to define default underline offset and opacity for all links
- Allow developers to easily override `background-position` to correctly set underlines for `block` or `inline-block` elements
- Removed conditional rules if the colour is set to "white"
- Added sensible fallback of `1.05em` for browsers that don't support `calc()`
